### PR TITLE
Allow retrieving the context path from a rule hit

### DIFF
--- a/lib/schematron-nokogiri.rb
+++ b/lib/schematron-nokogiri.rb
@@ -78,6 +78,7 @@ module SchematronNokogiri
               :type => node_type(context),
               :name => context.name,
               :line => context.line,
+              :context_path => context_path,
               :message => message.content.strip}
         end
       end


### PR DESCRIPTION
It can be useful to show the context path when displaying a schematron message.

Example before:
`{:rule_type=>"assert", :type=>"element", :name=>"SoftwareInfo", :line=>9, :message=>"element 'extension/SimulationControl' is OPTIONAL"}`

Example after:
`{:rule_type=>"assert", :type=>"element", :name=>"SoftwareInfo", :line=>9, :context_path=>"/h:HPXML/h:SoftwareInfo", :message=>"element 'extension/SimulationControl' is OPTIONAL"}`

I don't know the code well enough to know if this works in all situations, but it has been working well for us in our testing.